### PR TITLE
fix: remove animate flag after animation finished

### DIFF
--- a/src/SliderInner.tsx
+++ b/src/SliderInner.tsx
@@ -34,11 +34,14 @@ export const SliderInner = memo(function SliderInner({
   const ref = useRef<HTMLDivElement>(null);
 
   timeout_callback.current = () => {
-    if (progress_ref.current === 100 || progress_ref.current === -100)
-      unstable_batchedUpdates(() => {
+    unstable_batchedUpdates(() => {
+      if (progress_ref.current === 100 || progress_ref.current === -100) {
         set_current(old => old + 1 * Math.sign(progress_ref.current));
         set_progress(0);
-      });
+      }
+
+      set_animate(false);
+    });
   };
 
   useEffect(() => {
@@ -50,8 +53,6 @@ export const SliderInner = memo(function SliderInner({
       const start_position = get_mouse_position(event);
 
       if (!start_position) return;
-
-      set_animate(false);
 
       event.preventDefault();
 


### PR DESCRIPTION
### Description
<!-- Short description of changes made in PR -->
This PR fixes the bug with page being overflow by x axis in some cases.

The reason behind the bug is that image gets moved on the right from the stack and usually stays there with `display: none;` css rule, so it does not impact the page sizes.

However, in case slide was cancelled, element does not disappear and stays with `display: initial;`. This makes page overflow by x axis in some cases. 

To fix it, I added `set_animate(false)` at the end of each slide action. Previously it was called only after slide action start.